### PR TITLE
Fix: Add example config template to application.example.conf

### DIFF
--- a/src/main/resources/application.example.conf
+++ b/src/main/resources/application.example.conf
@@ -1,0 +1,21 @@
+api {
+  endpoint = "https://randomuser.me/api/?results=1&nat=au"
+}
+
+aws {
+  accessKey = "REPLACE_ME_ACCESS_KEY"
+  secretKey = "REPLACE_ME_SECRET_KEY"
+  s3Bucket = "firstsources3"
+  s3Path = "Big Sales Data.csv"
+  region = "us-east-1"
+}
+
+snowflake {
+  sfURL = "https://YOUR_ACCOUNT.snowflakecomputing.com"
+  sfUser = "REPLACE_ME"
+  sfPassword = "REPLACE_ME"
+  sfDatabase = "HANU_DB"
+  sfSchema = "HANU_SCHEMA"
+  sfWarehouse = "COMPUTE_WH"
+  sfRole = "ACCOUNTADMIN"
+}


### PR DESCRIPTION
- Restored the correct template content for `application.example.conf`
- Ensured sensitive values are excluded
- This file now serves as a safe configuration template for other developers
- `.gitignore` correctly ignores `application.conf` to prevent accidental secret leakage

Branch: Hanu_Branch → dev